### PR TITLE
Changing the default PermGen value, up to 192M

### DIFF
--- a/var/lib/xinit/default.cfg
+++ b/var/lib/xinit/default.cfg
@@ -214,8 +214,8 @@ MEM_MAX="512m"
 # the larger the perm gen needs to be.
 # If you change the default value you MUST uncomment
 # CATALINA_OPTS parameter.
-# Default value: "128m"
-MAX_PERM_SIZE="128m"
+# Default value: "192m"
+MAX_PERM_SIZE="192m"
 
 # TOMCAT_USER: user java will run as.
 # Default value: "tomcat"


### PR DESCRIPTION
At ludo's request (I find this better too, because I have to change this value for each new install)
