### PR TITLE
Fixes a bug where multiple java processes and a missing catalina.pid fil...

### DIFF
--- a/var/lib/xinit/functions
+++ b/var/lib/xinit/functions
@@ -66,12 +66,14 @@ stop_tomcat ()
         if [[ -n "$TOMCAT_PID" ]]; then
 
                 log "WARNING" "Java process still running. Killing it ..."
-		if [[ -n "`ps -eo pid | grep $TOMCAT_PID`" ]]; then
+                for PID in `echo $TOMCAT_PID`
+                        do
+                        if [[ -n "`ps -eo pid | grep $PID`" ]]; then
 
-	                kill -9 $TOMCAT_PID
-			sleep 2
-
-		fi
+                                kill -9 $PID
+                                sleep 2
+                        fi
+                        done
 
                 if [[ -e $CATALINA_PID ]]; then
 


### PR DESCRIPTION
...e causes a new process start loop.

 TOMCAT_PID="`ps auxww | grep ${TOMCAT_PROCESS_NAME} | grep ${TOMCAT_HOME}| awk '{print $2}'`"
root@server:/var/lib/xinit# ps auxww | grep tomcat | grep /usr/local/tomcat | awk '{print $2}

'
6130
29853
30151

The old code then attempted to do a kill -9 on the above variable which failed, leading to no processes being killed, and in some cases, a start loop:

06-09-2013 17:30:50 [INFO]: Starting Tomcat Server ...
06-09-2013 17:30:50 [INFO]: Starting Tomcat Server ...
06-09-2013 17:30:50 [INFO]: Starting Tomcat Server ...
06-09-2013 17:30:50 [INFO]: Starting Tomcat Server ...
06-09-2013 17:30:50 [INFO]: Starting Tomcat Server ...
06-09-2013 17:30:50 [INFO]: Starting Tomcat Server ...
